### PR TITLE
Accelerate with copilot

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Join the school soccer team and compete in matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["alex@mergington.edu", "mia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Practice and compete in basketball tournaments",
+        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Art Club": {
+        "description": "Explore your creativity through painting and drawing",
+        "schedule": "Mondays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "isabella@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Act, direct, and produce plays and performances",
+        "schedule": "Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["charlotte@mergington.edu", "amelia@mergington.edu"]
+    },
+    "Math Club": {
+        "description": "Solve challenging math problems and participate in competitions",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 10,
+        "participants": ["benjamin@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop public speaking and argumentation skills",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 12,
+        "participants": ["ella@mergington.edu", "harper@mergington.edu"]
     }
 }
 
@@ -51,6 +87,9 @@ def root():
 def get_activities():
     return activities
 
+# Validate student is not already signed up 
+def is_student_signed_up(activity_name: str, email: str):
+    return email in activities[activity_name]["participants"]
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -25,6 +25,7 @@ document.addEventListener("DOMContentLoaded", () => {
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <p><strong>Participants:</strong> ${details.participants.length > 0 ? details.participants.join(", ") : "None"}</p>
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -85,3 +85,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // Initialize app
   fetchActivities();
 });
+
+document.getElementById("dark-mode-toggle").addEventListener("click", () => {
+  document.body.classList.toggle("dark-mode");
+});

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,7 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <button id="dark-mode-toggle" class="dark-mode-toggle">Toggle Dark Mode</button>
     </header>
 
     <main>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,16 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.activity-card p strong {
+  color: #1a237e;
+}
+
+.activity-card p:last-of-type {
+  margin-top: 10px;
+  font-style: italic;
+  color: #555;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -103,6 +103,17 @@ body.dark-mode .activity-card {
   color: #555;
 }
 
+.activity-card p.participants {
+  margin-top: 10px;
+  font-size: 14px;
+  color: #333;
+  font-weight: bold;
+}
+
+body.dark-mode .activity-card p.participants {
+  color: #ccc;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -15,6 +15,11 @@ body {
   background-color: #f5f5f5;
 }
 
+body.dark-mode {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
 header {
   text-align: center;
   padding: 20px 0;
@@ -22,6 +27,10 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+body.dark-mode header {
+  background-color: #333;
 }
 
 header h1 {
@@ -50,6 +59,11 @@ section {
   max-width: 500px;
 }
 
+body.dark-mode section {
+  background-color: #1e1e1e;
+  color: #e0e0e0;
+}
+
 section h3 {
   margin-bottom: 20px;
   padding-bottom: 10px;
@@ -63,6 +77,11 @@ section h3 {
   border: 1px solid #ddd;
   border-radius: 5px;
   background-color: #f9f9f9;
+}
+
+body.dark-mode .activity-card {
+  background-color: #2a2a2a;
+  border-color: #444;
 }
 
 .activity-card h4 {
@@ -114,7 +133,34 @@ button {
   transition: background-color 0.2s;
 }
 
+body.dark-mode button {
+  background-color: #444;
+  color: #e0e0e0;
+}
+
 button:hover {
+  background-color: #3949ab;
+}
+
+body.dark-mode button:hover {
+  background-color: #555;
+}
+
+.dark-mode-toggle {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background-color: #1a237e;
+  color: white;
+  border: none;
+  padding: 10px 15px;
+  font-size: 14px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.dark-mode-toggle:hover {
   background-color: #3949ab;
 }
 


### PR DESCRIPTION
This pull request includes significant updates to the extracurricular activities management system, including new activities, validation for student sign-ups, and a dark mode feature for the user interface.

### New Activities and Validation:
* [`src/app.py`](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R41-R76): Added new activities including Soccer Team, Basketball Team, Art Club, Drama Club, Math Club, and Debate Team with their respective details. Introduced a validation function `is_student_signed_up` to check if a student is already signed up for an activity. [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R41-R76) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R90-R92)

### User Interface Enhancements:
* [`src/static/app.js`](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R28): Updated the activity details display to include the list of participants. Added an event listener for toggling dark mode. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R28) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R88-R91)
* [`src/static/index.html`](diffhunk://#diff-6c71709b4d31c8f650dbe64ffc24d55cede1d64448e827c4b1292ffeb2a3acc3R13): Added a button for toggling dark mode in the header.

### Dark Mode Styling:
* [`src/static/styles.css`](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R18-R22): Implemented dark mode styles for the body, header, sections, activity cards, and buttons. Added specific styles for the dark mode toggle button. [[1]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R18-R22) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R32-R35) [[3]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R62-R66) [[4]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R82-R86) [[5]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R96-R116) [[6]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R147-R177)